### PR TITLE
vita3K: ignore vzip unpredictable as result is already fine

### DIFF
--- a/src/dynarmic/frontend/A32/translate/impl/asimd_two_regs_misc.cpp
+++ b/src/dynarmic/frontend/A32/translate/impl/asimd_two_regs_misc.cpp
@@ -541,9 +541,10 @@ bool TranslatorVisitor::asimd_VZIP(bool D, size_t sz, size_t Vd, bool Q, bool M,
     const auto d = ToVector(Q, Vd, D);
     const auto m = ToVector(Q, Vm, M);
 
-    if (d == m) {
-        return UnpredictableInstruction();
-    }
+    // Vita3K: ignore unpredictables, result is fine as it is even if its techincally ub
+    // if (d == m) {
+    //     return UnpredictableInstruction();
+    // }
 
     const auto reg_d = ir.GetVector(d);
     const auto reg_m = ir.GetVector(m);


### PR DESCRIPTION
looks like just ignoring the check gives the correct result already for the vita cpu, afaik only need for speed mw uses this instruction this way, without this there is almost no 2d render, with it cutscenes and 2d works just fine like it should