### PR TITLE
frontend/A32, ir: Add missing include

### DIFF
--- a/src/dynarmic/frontend/A32/translate/impl/asimd_misc.cpp
+++ b/src/dynarmic/frontend/A32/translate/impl/asimd_misc.cpp
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: 0BSD
  */
 
+#include <vector>
+
 #include <mcl/assert.hpp>
 #include <mcl/bit/bit_count.hpp>
 #include <mcl/bit/bit_field.hpp>

--- a/src/dynarmic/ir/ir_emitter.cpp
+++ b/src/dynarmic/ir/ir_emitter.cpp
@@ -5,6 +5,8 @@
 
 #include "dynarmic/ir/ir_emitter.h"
 
+#include <vector>
+
 #include <mcl/assert.hpp>
 #include <mcl/bit_cast.hpp>
 


### PR DESCRIPTION
Cherry-pick https://github.com/merryhime/dynarmic/commit/1fa1935d7c015767cf211c441578b25e3517c43f because an Apple clang update broke the MacOS build.

Do not rebase yet because the dynarmic changes are mainly arm64 (will be done later with the android pr) and the changes will break Vita3K.